### PR TITLE
Build: add config files + improve MoveIt.csproj UI build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,105 @@
+root = true
+
+[*.cs]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+# ---- General style ----
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Prefer 'var' where it's obvious; otherwise prefer explicit type
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# Style analyzers
+dotnet_diagnostic.RCS1146.severity = suggestion   # Use conditional access (keep on)
+dotnet_diagnostic.RCS1226.severity = none         # Doc-paragraph nit = off
+dotnet_diagnostic.IDE0031.severity = silent       # Allow explicit null checks without Messages
+
+# Keep flat namespace; don't require folder-matching
+dotnet_style_namespace_match_folder = false:silent
+dotnet_diagnostic.IDE0130.severity = none         # Namespace vs folder
+
+# Our k/m/s scheme conflicts with IDE1006; quiet it
+dotnet_diagnostic.IDE1006.severity = none
+
+# =========================
+# Naming symbols (targets)
+# =========================
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = *
+
+dotnet_naming_symbols.types_and_members.applicable_kinds = class, struct, enum, property, method, event
+dotnet_naming_symbols.types_and_members.applicable_accessibilities = *
+
+dotnet_naming_symbols.private_instance_fields.applicable_kinds = field
+dotnet_naming_symbols.private_instance_fields.applicable_accessibilities = private
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
+
+# All const fields, any accessibility
+dotnet_naming_symbols.const_fields.applicable_kinds = field
+dotnet_naming_symbols.const_fields.required_modifiers = const
+dotnet_naming_symbols.const_fields.applicable_accessibilities = *
+
+# Explicitly include private/internal consts too (defensive)
+dotnet_naming_symbols.private_internal_const_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_const_fields.required_modifiers = const
+dotnet_naming_symbols.private_internal_const_fields.applicable_accessibilities = private, internal, protected_internal, private_protected
+
+# =========================
+# Naming styles (how)
+# =========================
+dotnet_naming_style.pascal.required_capitalization = pascal_case
+dotnet_naming_style.interface_i.required_prefix = I
+dotnet_naming_style.m_prefix.required_prefix = m_
+dotnet_naming_style.s_prefix.required_prefix = s_
+dotnet_naming_style.k_prefix_pascal.required_prefix = k
+dotnet_naming_style.k_prefix_pascal.required_capitalization = pascal_case
+dotnet_naming_style.camel.required_capitalization = camel_case
+
+# =========================
+# Rules (symbols × styles)
+# =========================
+# Interfaces: IName
+dotnet_naming_rule.interfaces_must_start_with_i.symbols = interfaces
+dotnet_naming_rule.interfaces_must_start_with_i.style = interface_i
+dotnet_naming_rule.interfaces_must_start_with_i.severity = suggestion
+
+# Types & non-field members: PascalCase
+dotnet_naming_rule.types_and_members_pascal.symbols = types_and_members
+dotnet_naming_rule.types_and_members_pascal.style = pascal
+dotnet_naming_rule.types_and_members_pascal.severity = suggestion
+
+# Private instance fields: m_name
+dotnet_naming_rule.private_instance_fields_m_prefix.symbols = private_instance_fields
+dotnet_naming_rule.private_instance_fields_m_prefix.style = m_prefix
+dotnet_naming_rule.private_instance_fields_m_prefix.severity = suggestion
+
+# Private static fields: s_name
+dotnet_naming_rule.private_static_fields_s_prefix.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_s_prefix.style = s_prefix
+dotnet_naming_rule.private_static_fields_s_prefix.severity = suggestion
+
+# Const fields: kName (all accessibilities)
+dotnet_naming_rule.const_fields_k_prefix.symbols = const_fields
+dotnet_naming_rule.const_fields_k_prefix.style = k_prefix_pascal
+dotnet_naming_rule.const_fields_k_prefix.severity = suggestion
+
+# Private/Internal const fields: kName (defensive duplicate)
+dotnet_naming_rule.private_internal_const_fields_k_prefix.symbols = private_internal_const_fields
+dotnet_naming_rule.private_internal_const_fields_k_prefix.style = k_prefix_pascal
+dotnet_naming_rule.private_internal_const_fields_k_prefix.severity = suggestion
+
+# Turn off CA1822 for False positives for Settings.cs because the game’s Options UI binds to instance
+# properties via reflection + attributes. If we make them static, they’ll stop showing/working in the UI.
+[Settings/Settings.cs]
+dotnet_diagnostic.CA1822.severity = none

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+* text=auto
+
+# Windows-style line endings for VS project files and C#
+*.sln      text eol=crlf
+*.csproj   text eol=crlf
+*.props    text eol=crlf
+*.targets  text eol=crlf
+*.cs       text eol=crlf
+# optional: LF renders nicer on GitHub
+*.md       text eol=lf
+*.json text eol=lf
+
+# Scripts
+*.sh       text eol=lf
+*.bash     text eol=lf
+*.ps1      text eol=crlf
+
+# Binaries
+*.png binary
+*.jpg binary
+*.svg binary
+*.ico binary

--- a/.gitignore
+++ b/.gitignore
@@ -184,8 +184,14 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+// *.pubxml
 *.publishproj
+
+# Track publish profiles (override any broader ignore)
+!Properties/PublishProfiles/*.pubxml
+
+# Ignore machine-specific publish profile user files
+*.pubxml.user
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to
 # checkin your Azure Web App publish settings, but sensitive information contained

--- a/.gitignore
+++ b/.gitignore
@@ -184,11 +184,15 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-// *.pubxml
+# Comment it out to allow pubxml in the repo.
+# *.pubxml
+
 *.publishproj
 
-# Track publish profiles (override any broader ignore)
-!Properties/PublishProfiles/*.pubxml
+# Allow CS2 publish profiles (track these)
+!**/Properties/
+!**/Properties/PublishProfiles/
+!**/Properties/PublishProfiles/*.pubxml
 
 # Ignore machine-specific publish profile user files
 *.pubxml.user

--- a/Code/MoveIt/MoveIt.csproj
+++ b/Code/MoveIt/MoveIt.csproj
@@ -30,10 +30,10 @@
 		<NpmCmd Condition="'$(NpmCmd)'==''">npm</NpmCmd>
 
 		<!-- UI build control:
-		     - Debug default: true (handy: set false to avoid slow/hanging builds during code iteration)
+		     - Debug default: true (recommend: set false to avoid slow/hanging builds during code testing)
 		     - Release/Stable default: true (ensure publish builds include UI) -->
 		<RunMoveItUIBuild Condition="'$(RunMoveItUIBuild)'=='' AND '$(Configuration)'=='Debug'">true</RunMoveItUIBuild>
-		<RunMoveItUIBuild Condition="'$(RunMoveItUIBuild)'=='' AND '$(Configuration)'!='Debug'">true</RunMoveItUIBuild>
+		<RunMoveItUIBuild Condition="'$(RunMoveItUIBuild)'=='' AND ( '$(Configuration)'=='Release' OR '$(Configuration)'=='Stable' )">true</RunMoveItUIBuild>
 
 		<!-- Move It UI project location (relative to this .csproj) -->
 		<MoveItUiDir>..\..\UI</MoveItUiDir>
@@ -44,7 +44,7 @@
 		<MoveItNpmCiStamp>$(MoveItUiFullDir)\node_modules\.stamp</MoveItNpmCiStamp>
 		<MoveItNpmBuildStamp>$(MSBuildProjectDirectory)\bin\UI\.ui.stamp</MoveItNpmBuildStamp>
 
-		<!-- Optional timeouts (ms). Exec default is infinite; these prevent “looks frozen forever” scenarios. -->
+		<!-- Optional timeouts (ms). Exec default is infinite; these prevent “looks stuck forever”. -->
 		<MoveItNpmCiTimeoutMs Condition="'$(MoveItNpmCiTimeoutMs)'==''">900000</MoveItNpmCiTimeoutMs>
 		<MoveItNpmBuildTimeoutMs Condition="'$(MoveItNpmBuildTimeoutMs)'==''">900000</MoveItNpmBuildTimeoutMs>
 	</PropertyGroup>
@@ -55,7 +55,7 @@
 	<Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.targets" />
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<!-- RELEASE is a custom define (not MSBuild).
+		<!-- RELEASE is custom define (not MSBuild).
        Mod.cs uses it to format Mod.Version as a 4-part string.
        Stable keeps the original 3-part version (ToString(3)). -->
 		<DefineConstants>$(DefineConstants);USE_BURST;RELEASE</DefineConstants>
@@ -72,7 +72,7 @@
 		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
 
-	<!-- Debug helper: print toolchain-provided MSCORLIBPath -->
+	<!-- Optional Debug helper: print toolchain-provided MSCORLIBPath -->
 	<Target Name="ShowMscorlibPath" BeforeTargets="Build" Condition="'$(Configuration)'=='Debug'">
 		<Message Importance="High" Text="MSCORLIBPath=$(MSCORLIBPath)" />
 	</Target>
@@ -87,75 +87,57 @@
 		<MoveItUiInputs Include="$(MoveItUiFullDir)\webpack.config.js" Condition="Exists('$(MoveItUiFullDir)\webpack.config.js')" />
 	</ItemGroup>
 
-	<!-- npm ci only when lockfile changes (tracked via .stamp) -->
+	<!-- npm ci Only when lockfile changes (tracked via .stamp) -->
 	<Target Name="MoveItNpmInstallIfNeeded"
-	        Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json') AND Exists('$(MoveItUiFullDir)\package-lock.json')"
-	        Inputs="$(MoveItUiFullDir)\package-lock.json"
-	        Outputs="$(MoveItNpmCiStamp)">
+			Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json') AND Exists('$(MoveItUiFullDir)\package-lock.json')"
+			Inputs="$(MoveItUiFullDir)\package-lock.json"
+			Outputs="$(MoveItNpmCiStamp)">
 		<Message Text="MOVE IT UI: npm ci (lockfile changed or first-time)..." Importance="high" />
 
-		<Exec Command="$(NpmCmd) ci"
-		      WorkingDirectory="$(MoveItUiFullDir)"
-		      IgnoreExitCode="true"
-		      Timeout="$(MoveItNpmCiTimeoutMs)">
+		<Exec Command="$(NpmCmd) ci" WorkingDirectory="$(MoveItUiFullDir)" IgnoreExitCode="true" Timeout="$(MoveItNpmCiTimeoutMs)">
 			<Output TaskParameter="ExitCode" PropertyName="MoveItNpmCiExit" />
 		</Exec>
 
 		<!-- Non-Debug configs: fail hard -->
-		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmCiExit)'!='0'"
-		       Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Build aborted." />
+		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmCiExit)'!='0'" Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Build aborted." />
 
 		<!-- Debug: warn -->
-		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmCiExit)'!='0'"
-		         Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Continuing (Debug)." />
+		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmCiExit)'!='0'" Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Continuing (Debug)." />
 
-		<WriteLinesToFile Condition="'$(MoveItNpmCiExit)'=='0'"
-		                  File="$(MoveItNpmCiStamp)"
-		                  Lines="ok"
-		                  Overwrite="true" />
+		<WriteLinesToFile Condition="'$(MoveItNpmCiExit)'=='0'" File="$(MoveItNpmCiStamp)" Lines="ok" Overwrite="true" />
 	</Target>
 
 	<!-- npm run build only when UI inputs changed (tracked via .ui.stamp) -->
 	<Target Name="MoveItUIBuild"
-	        DependsOnTargets="MoveItNpmInstallIfNeeded"
-	        Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json')"
-	        Inputs="@(MoveItUiInputs)"
-	        Outputs="$(MoveItNpmBuildStamp)">
+			DependsOnTargets="MoveItNpmInstallIfNeeded"
+			Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json')"
+			Inputs="@(MoveItUiInputs)"
+			Outputs="$(MoveItNpmBuildStamp)">
 		<Message Text="MOVE IT UI: npm run build ($(Configuration))..." Importance="high" />
 
-		<Exec Command="$(NpmCmd) run build"
-		      WorkingDirectory="$(MoveItUiFullDir)"
-		      IgnoreExitCode="true"
-		      Timeout="$(MoveItNpmBuildTimeoutMs)">
+		<Exec Command="$(NpmCmd) run build" WorkingDirectory="$(MoveItUiFullDir)" IgnoreExitCode="true" Timeout="$(MoveItNpmBuildTimeoutMs)">
 			<Output TaskParameter="ExitCode" PropertyName="MoveItNpmBuildExit" />
 		</Exec>
 
 		<!-- Non-Debug configs: fail hard -->
-		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmBuildExit)'!='0'"
-		       Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Build aborted." />
+		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmBuildExit)'!='0'" Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Build aborted." />
 
 		<!-- Debug: warn -->
-		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmBuildExit)'!='0'"
-		         Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Continuing (Debug)." />
+		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmBuildExit)'!='0'" Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Continuing (Debug)." />
 
-		<WriteLinesToFile Condition="'$(MoveItNpmBuildExit)'=='0'"
-		                  File="$(MoveItNpmBuildStamp)"
-		                  Lines="ok"
-		                  Overwrite="true" />
+		<WriteLinesToFile Condition="'$(MoveItNpmBuildExit)'=='0'" File="$(MoveItNpmBuildStamp)" Lines="ok" Overwrite="true" />
 	</Target>
 
-	<!-- Copy built UI into the deployed mod folder after toolchain deploy -->
+	<!-- Copy built UI into the deployed mod folder After toolchain deploy -->
 	<Target Name="CopyMoveItUIToDeploy"
-	        AfterTargets="DeployWIP"
-	        DependsOnTargets="MoveItUIBuild"
-	        Condition="Exists('$(MSBuildProjectDirectory)\bin\UI')">
+			AfterTargets="DeployWIP"
+			DependsOnTargets="MoveItUIBuild"
+			Condition="Exists('$(MSBuildProjectDirectory)\bin\UI')">
 		<ItemGroup>
 			<UIFiles Include="bin\UI\**\*.*" />
 		</ItemGroup>
 
-		<Copy SourceFiles="@(UIFiles)"
-		      DestinationFiles="@(UIFiles->'$(DeployDir)\%(RecursiveDir)%(Filename)%(Extension)')"
-		      SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(UIFiles)" DestinationFiles="@(UIFiles->'$(DeployDir)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
 	</Target>
 
 	<Target Name="SetupAttributes" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' != 'Debug'">

--- a/Code/MoveIt/MoveIt.csproj
+++ b/Code/MoveIt/MoveIt.csproj
@@ -1,53 +1,161 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+	<!-- File: MoveIt.csproj -->
+	<!-- Purpose: Build configuration for Move It mod using the CSII toolchain.
+	     Notes: TargetFramework net48 is set by toolchain Mod.props. -->
 
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
 		<LangVersion>9</LangVersion>
 		<Configurations>Debug;Release;Stable</Configurations>
 		<Deterministic>False</Deterministic>
-		
-		<!--The folder where Game.dll is located. Set it only if the game is not installed in the default location, otherwise keep it empty-->
+
+		<!-- The folder where Game.dll is located. Set it only if the game is not installed in the default location, otherwise keep it empty -->
 		<CustomManagedPath></CustomManagedPath>
-		
-		<!--The file where mod information which is required for publishing mod on PDX mods are stored-->
+
+		<!-- The file where mod information required for publishing on PDX Mods is stored -->
 		<PublishConfigurationPath>Properties\$(Configuration)\PublishConfiguration.xml</PublishConfigurationPath>
-    <Version>0.6.1.1</Version>
-    <AssemblyVersion>$(AssemblyVersion)</AssemblyVersion>
-    <FileVersion>$(AssemblyVersion)</FileVersion>
+
+		<!-- Single source of truth for version:
+		     - Used by PDX publishing (SetupAttributes target)
+		     - Used by Mod.Version via Assembly.GetName().Version -->
+		<Version>0.6.1.1</Version>
+		<AssemblyVersion>$(Version)</AssemblyVersion>
+		<FileVersion>$(Version)</FileVersion>
+
+		<!-- Explicit for clarity -->
+		<AssemblyName>MoveIt</AssemblyName>
+		<RootNamespace>MoveIt</RootNamespace>
+
+		<!-- NPM runner -->
+		<NpmCmd Condition="'$(NpmCmd)'==''">npm</NpmCmd>
+
+		<!-- UI build control:
+		     - Debug default: true (handy: set false to avoid slow/hanging builds during code iteration)
+		     - Release/Stable default: true (ensure publish builds include UI) -->
+		<RunMoveItUIBuild Condition="'$(RunMoveItUIBuild)'=='' AND '$(Configuration)'=='Debug'">true</RunMoveItUIBuild>
+		<RunMoveItUIBuild Condition="'$(RunMoveItUIBuild)'=='' AND '$(Configuration)'!='Debug'">true</RunMoveItUIBuild>
+
+		<!-- Move It UI project location (relative to this .csproj) -->
+		<MoveItUiDir>..\..\UI</MoveItUiDir>
+		<MoveItUiFullDir>$(MSBuildProjectDirectory)\$(MoveItUiDir)</MoveItUiFullDir>
+
+		<!-- Stamp files: tiny marker used by MSBuild incremental build.
+     If inputs haven't changed since the stamp was written, MSBuild skips rerunning npm. -->
+		<MoveItNpmCiStamp>$(MoveItUiFullDir)\node_modules\.stamp</MoveItNpmCiStamp>
+		<MoveItNpmBuildStamp>$(MSBuildProjectDirectory)\bin\UI\.ui.stamp</MoveItNpmBuildStamp>
+
+		<!-- Optional timeouts (ms). Exec default is infinite; these prevent “looks frozen forever” scenarios. -->
+		<MoveItNpmCiTimeoutMs Condition="'$(MoveItNpmCiTimeoutMs)'==''">900000</MoveItNpmCiTimeoutMs>
+		<MoveItNpmBuildTimeoutMs Condition="'$(MoveItNpmBuildTimeoutMs)'==''">900000</MoveItNpmBuildTimeoutMs>
 	</PropertyGroup>
-	
+
 	<!--Imports must be after PropertyGroup block-->
 	<Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.props" />
 	<Import Project="..\..\..\QCommon2\Code\QCommon\QCommon\Shared\QCommonShared.projitems" Label="Shared" />
 	<Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.targets" />
-	<PropertyGroup>
-		<TargetFramework>net472</TargetFramework>
-	</PropertyGroup>
-	
+
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);USE_BURST</DefineConstants>
-	  <WarningLevel>4</WarningLevel>
+		<!-- RELEASE is a custom define (not MSBuild).
+       Mod.cs uses it to format Mod.Version as a 4-part string.
+       Stable keeps the original 3-part version (ToString(3)). -->
+		<DefineConstants>$(DefineConstants);USE_BURST;RELEASE</DefineConstants>
+		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
-	
+
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Stable|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);USE_BURST</DefineConstants>
-	  <WarningLevel>4</WarningLevel>
+		<DefineConstants>$(DefineConstants);USE_BURST</DefineConstants>
+		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-	  <DefineConstants>$(DefineConstants);ENABLE_PROFILER;IS_DEBUG;USE_BURST</DefineConstants>
-	  <WarningLevel>4</WarningLevel>
+		<DefineConstants>$(DefineConstants);ENABLE_PROFILER;IS_DEBUG;USE_BURST</DefineConstants>
+		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
-	
-	
-	<Target Name="CopyFiles" AfterTargets="DeployWIP">
+
+	<!-- Debug helper: print toolchain-provided MSCORLIBPath -->
+	<Target Name="ShowMscorlibPath" BeforeTargets="Build" Condition="'$(Configuration)'=='Debug'">
+		<Message Importance="High" Text="MSCORLIBPath=$(MSCORLIBPath)" />
+	</Target>
+
+	<!-- UI Inputs for incremental build (kept intentionally broad, but limited to common files/folders) -->
+	<ItemGroup Condition="Exists('$(MoveItUiFullDir)\package.json')">
+		<MoveItUiInputs Include="$(MoveItUiFullDir)\package.json" />
+		<MoveItUiInputs Include="$(MoveItUiFullDir)\package-lock.json" Condition="Exists('$(MoveItUiFullDir)\package-lock.json')" />
+		<MoveItUiInputs Include="$(MoveItUiFullDir)\src\**\*.*" Condition="Exists('$(MoveItUiFullDir)\src')" />
+		<MoveItUiInputs Include="$(MoveItUiFullDir)\public\**\*.*" Condition="Exists('$(MoveItUiFullDir)\public')" />
+		<MoveItUiInputs Include="$(MoveItUiFullDir)\tsconfig.json" Condition="Exists('$(MoveItUiFullDir)\tsconfig.json')" />
+		<MoveItUiInputs Include="$(MoveItUiFullDir)\webpack.config.js" Condition="Exists('$(MoveItUiFullDir)\webpack.config.js')" />
+	</ItemGroup>
+
+	<!-- npm ci only when lockfile changes (tracked via .stamp) -->
+	<Target Name="MoveItNpmInstallIfNeeded"
+	        Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json') AND Exists('$(MoveItUiFullDir)\package-lock.json')"
+	        Inputs="$(MoveItUiFullDir)\package-lock.json"
+	        Outputs="$(MoveItNpmCiStamp)">
+		<Message Text="MOVE IT UI: npm ci (lockfile changed or first-time)..." Importance="high" />
+
+		<Exec Command="$(NpmCmd) ci"
+		      WorkingDirectory="$(MoveItUiFullDir)"
+		      IgnoreExitCode="true"
+		      Timeout="$(MoveItNpmCiTimeoutMs)">
+			<Output TaskParameter="ExitCode" PropertyName="MoveItNpmCiExit" />
+		</Exec>
+
+		<!-- Non-Debug configs: fail hard -->
+		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmCiExit)'!='0'"
+		       Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Build aborted." />
+
+		<!-- Debug: warn -->
+		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmCiExit)'!='0'"
+		         Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Continuing (Debug)." />
+
+		<WriteLinesToFile Condition="'$(MoveItNpmCiExit)'=='0'"
+		                  File="$(MoveItNpmCiStamp)"
+		                  Lines="ok"
+		                  Overwrite="true" />
+	</Target>
+
+	<!-- npm run build only when UI inputs changed (tracked via .ui.stamp) -->
+	<Target Name="MoveItUIBuild"
+	        DependsOnTargets="MoveItNpmInstallIfNeeded"
+	        Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json')"
+	        Inputs="@(MoveItUiInputs)"
+	        Outputs="$(MoveItNpmBuildStamp)">
+		<Message Text="MOVE IT UI: npm run build ($(Configuration))..." Importance="high" />
+
+		<Exec Command="$(NpmCmd) run build"
+		      WorkingDirectory="$(MoveItUiFullDir)"
+		      IgnoreExitCode="true"
+		      Timeout="$(MoveItNpmBuildTimeoutMs)">
+			<Output TaskParameter="ExitCode" PropertyName="MoveItNpmBuildExit" />
+		</Exec>
+
+		<!-- Non-Debug configs: fail hard -->
+		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmBuildExit)'!='0'"
+		       Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Build aborted." />
+
+		<!-- Debug: warn -->
+		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmBuildExit)'!='0'"
+		         Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Continuing (Debug)." />
+
+		<WriteLinesToFile Condition="'$(MoveItNpmBuildExit)'=='0'"
+		                  File="$(MoveItNpmBuildStamp)"
+		                  Lines="ok"
+		                  Overwrite="true" />
+	</Target>
+
+	<!-- Copy built UI into the deployed mod folder after toolchain deploy -->
+	<Target Name="CopyMoveItUIToDeploy"
+	        AfterTargets="DeployWIP"
+	        DependsOnTargets="MoveItUIBuild"
+	        Condition="Exists('$(MSBuildProjectDirectory)\bin\UI')">
 		<ItemGroup>
 			<UIFiles Include="bin\UI\**\*.*" />
 		</ItemGroup>
-		
-		<Exec Command="npm run build --prefix ..\..\UI" />
-		
-		<Copy SourceFiles="@(UIFiles)" DestinationFiles="@(UIFiles->'$(DeployDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
+
+		<Copy SourceFiles="@(UIFiles)"
+		      DestinationFiles="@(UIFiles->'$(DeployDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+		      SkipUnchangedFiles="true" />
 	</Target>
 
 	<Target Name="SetupAttributes" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' != 'Debug'">
@@ -57,121 +165,123 @@
 	</Target>
 
 	<ItemGroup>
-	  <Compile Remove="Extensions\**" />
-	  <EmbeddedResource Remove="Extensions\**" />
-	  <None Remove="Extensions\**" />
+		<Compile Remove="Extensions\**" />
+		<EmbeddedResource Remove="Extensions\**" />
+		<None Remove="Extensions\**" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Remove="l10n\de-DE.json" />
-	  <None Remove="l10n\en-US.json" />
-	  <None Remove="l10n\es-ES.json" />
-	  <None Remove="l10n\fr-FR.json" />
-	  <None Remove="l10n\ja-JP.json" />
-	  <None Remove="l10n\ko-KR.json" />
-	  <None Remove="l10n\nl-NL.json" />
-	  <None Remove="l10n\pl-PL.json" />
-	  <None Remove="l10n\pt-BR.json" />
-	  <None Remove="l10n\pt-PT.json" />
-	  <None Remove="l10n\ru-RU.json" />
-	  <None Remove="l10n\zh-HANS.json" />
-	  <None Remove="l10n\zh-HANT.json" />
+		<None Remove="l10n\de-DE.json" />
+		<None Remove="l10n\en-US.json" />
+		<None Remove="l10n\es-ES.json" />
+		<None Remove="l10n\fr-FR.json" />
+		<None Remove="l10n\ja-JP.json" />
+		<None Remove="l10n\ko-KR.json" />
+		<None Remove="l10n\nl-NL.json" />
+		<None Remove="l10n\pl-PL.json" />
+		<None Remove="l10n\pt-BR.json" />
+		<None Remove="l10n\pt-PT.json" />
+		<None Remove="l10n\ru-RU.json" />
+		<None Remove="l10n\zh-HANS.json" />
+		<None Remove="l10n\zh-HANT.json" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <EmbeddedResource Include="l10n\de-DE.json" />
-	  <EmbeddedResource Include="l10n\es-ES.json" />
-	  <EmbeddedResource Include="l10n\fr-FR.json" />
-	  <EmbeddedResource Include="l10n\ja-JP.json" />
-	  <EmbeddedResource Include="l10n\ko-KR.json">
-	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-	  </EmbeddedResource>
-	  <EmbeddedResource Include="l10n\pl-PL.json" />
-	  <EmbeddedResource Include="l10n\pt-BR.json" />
-	  <EmbeddedResource Include="l10n\ru-RU.json">
-	    <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-	  </EmbeddedResource>
-	  <EmbeddedResource Include="l10n\zh-HANS.json" />
-	  <EmbeddedResource Include="l10n\zh-HANT.json" />
+		<EmbeddedResource Include="l10n\de-DE.json" />
+		<EmbeddedResource Include="l10n\es-ES.json" />
+		<EmbeddedResource Include="l10n\fr-FR.json" />
+		<EmbeddedResource Include="l10n\ja-JP.json" />
+		<EmbeddedResource Include="l10n\ko-KR.json">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<EmbeddedResource Include="l10n\pl-PL.json" />
+		<EmbeddedResource Include="l10n\pt-BR.json" />
+		<EmbeddedResource Include="l10n\ru-RU.json">
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</EmbeddedResource>
+		<EmbeddedResource Include="l10n\zh-HANS.json" />
+		<EmbeddedResource Include="l10n\zh-HANT.json" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<Reference Include="Colossal.Collections">
-		  <HintPath>$(ManagedPath)\Colossal.Collections.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.Collections.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Colossal.Core">
-		  <HintPath>$(ManagedPath)\Colossal.Core.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.Core.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Colossal.IO.AssetDatabase">
-		  <HintPath>$(ManagedPath)\Colossal.IO.AssetDatabase.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.IO.AssetDatabase.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Colossal.Localization">
-		  <HintPath>$(ManagedPath)\Colossal.Localization.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.Localization.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Colossal.Logging">
-		  <HintPath>$(ManagedPath)\Colossal.Logging.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.Logging.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Colossal.Mathematics">
-		  <HintPath>$(ManagedPath)\Colossal.Mathematics.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.Mathematics.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Colossal.PSI.Common">
-		  <HintPath>$(ManagedPath)\Colossal.PSI.Common.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.PSI.Common.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Colossal.UI">
-		  <HintPath>$(ManagedPath)\Colossal.UI.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.UI.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Colossal.UI.Binding">
-		  <HintPath>$(ManagedPath)\Colossal.UI.Binding.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Colossal.UI.Binding.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Game">
-		  <HintPath>$(ManagedPath)\Game.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Game.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
-		  <HintPath>$(ManagedPath)\Newtonsoft.Json.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Newtonsoft.Json.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Unity.Burst">
-		  <HintPath>$(ManagedPath)\Unity.Burst.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Unity.Burst.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Unity.Collections">
-		  <HintPath>$(ManagedPath)\Unity.Collections.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Unity.Collections.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Unity.Entities">
-		  <HintPath>$(ManagedPath)\Unity.Entities.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Unity.Entities.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Unity.InputSystem">
-		  <HintPath>$(ManagedPath)\Unity.InputSystem.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Unity.InputSystem.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="Unity.Mathematics">
-		  <HintPath>$(ManagedPath)\Unity.Mathematics.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\Unity.Mathematics.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine">
-		  <HintPath>$(ManagedPath)\UnityEngine.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\UnityEngine.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine.CoreModule">
-		  <HintPath>$(ManagedPath)\UnityEngine.CoreModule.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\UnityEngine.CoreModule.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine.IMGUIModule">
-		  <HintPath>$(ManagedPath)\UnityEngine.IMGUIModule.dll</HintPath>
-		  <Private>False</Private>
+			<HintPath>$(ManagedPath)\UnityEngine.IMGUIModule.dll</HintPath>
+			<Private>False</Private>
 		</Reference>
+
+		<!-- Keep: removing this causes CS0518 / missing predefined types in this project -->
 		<Reference Include="mscorlib">
 			<Private>False</Private>
 			<HintPath>$(ManagedPath)\mscorlib.dll</HintPath>
@@ -179,9 +289,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Update="C:\Program Files %28x86%29\Steam\steamapps\common\Cities Skylines II\Cities2_Data\Managed\mscorlib.dll">
-		  <Private>False</Private>
-		</Reference>
 		<Reference Update="System">
 			<Private>False</Private>
 		</Reference>
@@ -199,55 +306,40 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+		<PackageReference Include="System.IO.Compression" Version="4.3.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Update="lang\pt-PT.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
-	  <None Update="LICENSE.txt">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
-	  <None Update="UnofficialLocales\nl-NL.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
-	</ItemGroup>
-  
-	<ItemGroup>
-	  <Reference Update="System.Drawing">
-	    <Private>False</Private>
-	  </Reference>
+		<None Update="lang\pt-PT.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="LICENSE.txt">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+		<None Update="UnofficialLocales\nl-NL.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Reference Update="System.IO.Compression.FileSystem">
-	    <Private>False</Private>
-	  </Reference>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Reference Update="System.Numerics">
-	    <Private>False</Private>
-	  </Reference>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Reference Update="System.Runtime.Serialization">
-	    <Private>False</Private>
-	  </Reference>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Reference Update="System.Xml">
-	    <Private>False</Private>
-	  </Reference>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Reference Update="System.Xml.Linq">
-	    <Private>False</Private>
-	  </Reference>
+		<Reference Update="System.Drawing">
+			<Private>False</Private>
+		</Reference>
+		<Reference Update="System.IO.Compression.FileSystem">
+			<Private>False</Private>
+		</Reference>
+		<Reference Update="System.Numerics">
+			<Private>False</Private>
+		</Reference>
+		<Reference Update="System.Runtime.Serialization">
+			<Private>False</Private>
+		</Reference>
+		<Reference Update="System.Xml">
+			<Private>False</Private>
+		</Reference>
+		<Reference Update="System.Xml.Linq">
+			<Private>False</Private>
+		</Reference>
 	</ItemGroup>
 
 	<ItemGroup>
@@ -282,5 +374,4 @@
 			<DependentUpon>MIT_OverlaySystem.cs</DependentUpon>
 		</Compile>
 	</ItemGroup>
-	
 </Project>

--- a/Code/MoveIt/Properties/PublishProfiles/PublishNewMod.pubxml
+++ b/Code/MoveIt/Properties/PublishProfiles/PublishNewMod.pubxml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<Configuration>Release</Configuration>
+		<Platform>Any CPU</Platform>
+		<PublishProtocol>FileSystem</PublishProtocol>
+		<_TargetId>Folder</_TargetId>
+		<TargetFramework>net48</TargetFramework>
+		<PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
+		<ModPublisherCommand>Publish</ModPublisherCommand>
+	</PropertyGroup>
+</Project>

--- a/Code/MoveIt/Properties/PublishProfiles/PublishNewVersion.pubxml
+++ b/Code/MoveIt/Properties/PublishProfiles/PublishNewVersion.pubxml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<Configuration>Release</Configuration>
+		<Platform>Any CPU</Platform>
+		<PublishProtocol>FileSystem</PublishProtocol>
+		<_TargetId>Folder</_TargetId>
+		<TargetFramework>net48</TargetFramework>
+		<PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
+		<ModPublisherCommand>NewVersion</ModPublisherCommand>
+	</PropertyGroup>
+</Project>

--- a/Code/MoveIt/Properties/PublishProfiles/UpdatePublishedConfiguration.pubxml
+++ b/Code/MoveIt/Properties/PublishProfiles/UpdatePublishedConfiguration.pubxml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<PropertyGroup>
+		<Configuration>Release</Configuration>
+		<Platform>Any CPU</Platform>
+		<PublishProtocol>FileSystem</PublishProtocol>
+		<_TargetId>Folder</_TargetId>
+		<TargetFramework>net48</TargetFramework>
+		<PublishDir>bin\$(Configuration)\$(TargetFramework)\</PublishDir>
+		<ModPublisherCommand>Update</ModPublisherCommand>
+	</PropertyGroup>
+</Project>


### PR DESCRIPTION
### Summary

- Adds config files:` .editorconfig`,` .gitattributes`
- Updates` .gitignore`  to track PublishProfiles (*.pubxml).
- Updates `MoveIt.csproj ` to make UI build easier to control.

### MoveIt.csproj changes

- Uses `$(Version)` for AssemblyVersion and FileVersion (single source of truth).
- Adds `RunMoveItUIBuild ` MSBuild property so UI building can be enabled/disabled without editing targets.
    - Example: skip UI build for Debug (faster to test cs), while keeping Release/Stable building UI.
    - optional: can also override at build time:
        `msbuild Code/MoveIt/MoveIt.csproj /p:RunMoveItUIBuild=false`

- Adds incremental UI build targets:
  - `npm ci` runs only when `package-lock.json` **changes** (tracked with stamp file).
  - `npm run build` runs only when UI inputs change (stamp file).
      - stamp/marker:  a small file written after a successful run, used only to skip unnecessary repeats)
  - Reliable: copies built UI after deploy so deployed mod includes UI assets.

- Adds optional timeouts and better messages/warnings so npm/MSBuild doesn't look “stuck”.
- MSBuild Exec can sit there forever if npm hangs (happened to me).
    - 900,000 ms = 900 seconds = 15 minutes (suggest 3-5 min)
  
### Notes
- No code/runtime behavior changes - csproj build and config files only.