### PR TITLE
fix: UI build order after DeployWIP + optional npm ci knobs (csproj)

### DIFF
--- a/Code/MoveIt/MoveIt.csproj
+++ b/Code/MoveIt/MoveIt.csproj
@@ -26,38 +26,58 @@
 		<AssemblyName>MoveIt</AssemblyName>
 		<RootNamespace>MoveIt</RootNamespace>
 
-		<!-- NPM runner -->
-		<NpmCmd Condition="'$(NpmCmd)'==''">npm</NpmCmd>
+		<!-- ============================================================
+		     UI build controls (3 knobs)
+		     ============================================================
 
-		<!-- UI build control:
-		     - Debug default: true (recommend: set false to avoid slow/hanging builds during code testing)
-		     - Release/Stable default: true (ensure publish builds include UI) -->
-		<RunMoveItUIBuild Condition="'$(RunMoveItUIBuild)'=='' AND '$(Configuration)'=='Debug'">true</RunMoveItUIBuild>
-		<RunMoveItUIBuild Condition="'$(RunMoveItUIBuild)'=='' AND ( '$(Configuration)'=='Release' OR '$(Configuration)'=='Stable' )">true</RunMoveItUIBuild>
+		     1) RunMoveItUIBuild (master switch)
+		        - true  = run UI build + copy UI output into $(DeployDir)
+		        - false = skip ALL UI steps (no npm ci, no npm run build, no copy)
 
-		<!-- Move It UI project location (relative to this .csproj) -->
+		     2) RunMoveItNpmCi (enable/disable npm ci entirely)
+		        - true  = allow npm ci behavior below
+		        - false = never run npm ci from MSBuild (manual terminal only)
+
+		     3) MoveItForceNpmCiAlways (npm ci mode)
+		        - true  = run npm ci every build (no stamp)
+		        - false = run npm ci only when package-lock.json changes (stamp-marker)
+
+		     Recommended defaults:
+		       RunMoveItUIBuild=true
+		       RunMoveItNpmCi=true
+		       MoveItForceNpmCiAlways=false
+		-->
+
+		<!-- Master on/off for ALL UI steps (build + copy). -->
+		<RunMoveItUIBuild Condition="'$(RunMoveItUIBuild)'==''">true</RunMoveItUIBuild>
+
+		<!-- Enable/disable npm ci from MSBuild (separate from npm run build). -->
+		<RunMoveItNpmCi Condition="'$(RunMoveItNpmCi)'==''">true</RunMoveItNpmCi>
+
+		<!-- Force npm ci every build (default false = only when package-lock.json changes). -->
+		<MoveItForceNpmCiAlways Condition="'$(MoveItForceNpmCiAlways)'==''">false</MoveItForceNpmCiAlways>
+
+		<!-- UI project location (relative to this .csproj). -->
 		<MoveItUiDir>..\..\UI</MoveItUiDir>
 		<MoveItUiFullDir>$(MSBuildProjectDirectory)\$(MoveItUiDir)</MoveItUiFullDir>
 
-		<!-- Stamp files: tiny marker used by MSBuild incremental build.
-     If inputs haven't changed since the stamp was written, MSBuild skips rerunning npm. -->
-		<MoveItNpmCiStamp>$(MoveItUiFullDir)\node_modules\.stamp</MoveItNpmCiStamp>
-		<MoveItNpmBuildStamp>$(MSBuildProjectDirectory)\bin\UI\.ui.stamp</MoveItNpmBuildStamp>
+		<!-- Stamp file used only for the "npm ci only when package-lock.json changes" mode. -->
+		<MoveItNpmCiStamp>$(MoveItUiFullDir)\node_modules\.moveit-npmci.stamp</MoveItNpmCiStamp>
 
-		<!-- Optional timeouts (ms). Exec default is infinite; these prevent “looks stuck forever”. -->
+		<!-- Optional timeouts (ms). Exec default is Infinite; these prevent "looks stuck forever". -->
 		<MoveItNpmCiTimeoutMs Condition="'$(MoveItNpmCiTimeoutMs)'==''">900000</MoveItNpmCiTimeoutMs>
 		<MoveItNpmBuildTimeoutMs Condition="'$(MoveItNpmBuildTimeoutMs)'==''">900000</MoveItNpmBuildTimeoutMs>
 	</PropertyGroup>
 
-	<!--Imports must be after PropertyGroup block-->
+	<!-- Imports must be after PropertyGroup block -->
 	<Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.props" />
 	<Import Project="..\..\..\QCommon2\Code\QCommon\QCommon\Shared\QCommonShared.projitems" Label="Shared" />
 	<Import Project="$([System.Environment]::GetEnvironmentVariable('CSII_TOOLPATH', 'EnvironmentVariableTarget.User'))\Mod.targets" />
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<!-- RELEASE is custom define (not MSBuild).
-       Mod.cs uses it to format Mod.Version as a 4-part string.
-       Stable keeps the original 3-part version (ToString(3)). -->
+		<!-- RELEASE is custom (not MSBuild) and must be defined here along with USE_BURST.
+		     Because Mod.cs uses RELEASE to format Mod.Version as a 4-part string.
+		     Stable keeps the original 3-part version (ToString(3)). -->
 		<DefineConstants>$(DefineConstants);USE_BURST;RELEASE</DefineConstants>
 		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
@@ -72,72 +92,119 @@
 		<WarningLevel>4</WarningLevel>
 	</PropertyGroup>
 
-	<!-- Optional Debug helper: print toolchain-provided MSCORLIBPath -->
-	<Target Name="ShowMscorlibPath" BeforeTargets="Build" Condition="'$(Configuration)'=='Debug'">
-		<Message Importance="High" Text="MSCORLIBPath=$(MSCORLIBPath)" />
+	<!-- ============================================================
+	     npm ci (optional install dependencies step)
+	     ============================================================
+	     What this does:
+	       - Runs "npm ci" in the UI folder, using package-lock.json.
+	       - Creates clean node_modules.
+	     When it runs:
+	       - Only if RunMoveItUIBuild=true AND RunMoveItNpmCi=true
+	       - And only if UI/package-lock.json exists (req. for npm ci)
+	     Modes:
+	       - MoveItForceNpmCiAlways=true  => run every build (no stamp)
+	       - MoveItForceNpmCiAlways=false => run only when package-lock.json changes (stamp)
+	-->
+
+	<!-- Router target: picks the npm ci mode (always run vs lockfile-changed). -->
+	<Target Name="MoveItNpmInstall"
+	        Condition="'$(RunMoveItUIBuild)'=='true' AND '$(RunMoveItNpmCi)'=='true' AND Exists('$(MoveItUiFullDir)\package.json') AND Exists('$(MoveItUiFullDir)\package-lock.json')">
+		<CallTarget Targets="MoveItNpmInstallAlways" Condition="'$(MoveItForceNpmCiAlways)'=='true'" />
+		<CallTarget Targets="MoveItNpmInstallIfNeeded" Condition="'$(MoveItForceNpmCiAlways)'!='true'" />
 	</Target>
 
-	<!-- UI Inputs for incremental build (kept intentionally broad, but limited to common files/folders) -->
-	<ItemGroup Condition="Exists('$(MoveItUiFullDir)\package.json')">
-		<MoveItUiInputs Include="$(MoveItUiFullDir)\package.json" />
-		<MoveItUiInputs Include="$(MoveItUiFullDir)\package-lock.json" Condition="Exists('$(MoveItUiFullDir)\package-lock.json')" />
-		<MoveItUiInputs Include="$(MoveItUiFullDir)\src\**\*.*" Condition="Exists('$(MoveItUiFullDir)\src')" />
-		<MoveItUiInputs Include="$(MoveItUiFullDir)\public\**\*.*" Condition="Exists('$(MoveItUiFullDir)\public')" />
-		<MoveItUiInputs Include="$(MoveItUiFullDir)\tsconfig.json" Condition="Exists('$(MoveItUiFullDir)\tsconfig.json')" />
-		<MoveItUiInputs Include="$(MoveItUiFullDir)\webpack.config.js" Condition="Exists('$(MoveItUiFullDir)\webpack.config.js')" />
-	</ItemGroup>
+	<!-- Mode A: npm ci every build (no stamp needed). -->
+	<Target Name="MoveItNpmInstallAlways"
+	        Condition="'$(RunMoveItUIBuild)'=='true' AND '$(RunMoveItNpmCi)'=='true' AND '$(MoveItForceNpmCiAlways)'=='true' AND Exists('$(MoveItUiFullDir)\package-lock.json')">
+		<Message Text="MOVE IT UI: npm ci (forced every build)..." Importance="high" />
 
-	<!-- npm ci Only when lockfile changes (tracked via .stamp) -->
-	<Target Name="MoveItNpmInstallIfNeeded"
-			Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json') AND Exists('$(MoveItUiFullDir)\package-lock.json')"
-			Inputs="$(MoveItUiFullDir)\package-lock.json"
-			Outputs="$(MoveItNpmCiStamp)">
-		<Message Text="MOVE IT UI: npm ci (lockfile changed or first-time)..." Importance="high" />
-
-		<Exec Command="$(NpmCmd) ci" WorkingDirectory="$(MoveItUiFullDir)" IgnoreExitCode="true" Timeout="$(MoveItNpmCiTimeoutMs)">
+		<Exec Command="npm ci"
+		      WorkingDirectory="$(MoveItUiFullDir)"
+		      IgnoreExitCode="true"
+		      Timeout="$(MoveItNpmCiTimeoutMs)">
 			<Output TaskParameter="ExitCode" PropertyName="MoveItNpmCiExit" />
 		</Exec>
 
 		<!-- Non-Debug configs: fail hard -->
-		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmCiExit)'!='0'" Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Build aborted." />
+		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmCiExit)'!='0'"
+		       Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Build aborted." />
 
 		<!-- Debug: warn -->
-		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmCiExit)'!='0'" Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Continuing (Debug)." />
-
-		<WriteLinesToFile Condition="'$(MoveItNpmCiExit)'=='0'" File="$(MoveItNpmCiStamp)" Lines="ok" Overwrite="true" />
+		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmCiExit)'!='0'"
+		         Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Continuing (Debug)." />
 	</Target>
 
-	<!-- npm run build only when UI inputs changed (tracked via .ui.stamp) -->
-	<Target Name="MoveItUIBuild"
-			DependsOnTargets="MoveItNpmInstallIfNeeded"
-			Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json')"
-			Inputs="@(MoveItUiInputs)"
-			Outputs="$(MoveItNpmBuildStamp)">
-		<Message Text="MOVE IT UI: npm run build ($(Configuration))..." Importance="high" />
+	<!-- Mode B (recommended): npm ci Only when package-lock.json changes (stamp-based). -->
+	<Target Name="MoveItNpmInstallIfNeeded"
+	        Condition="'$(RunMoveItUIBuild)'=='true' AND '$(RunMoveItNpmCi)'=='true' AND '$(MoveItForceNpmCiAlways)'!='true' AND Exists('$(MoveItUiFullDir)\package-lock.json')"
+	        Inputs="$(MoveItUiFullDir)\package-lock.json"
+	        Outputs="$(MoveItNpmCiStamp)">
+		<Message Text="MOVE IT UI: npm ci (first-time or package-lock.json changed)..." Importance="high" />
 
-		<Exec Command="$(NpmCmd) run build" WorkingDirectory="$(MoveItUiFullDir)" IgnoreExitCode="true" Timeout="$(MoveItNpmBuildTimeoutMs)">
+		<Exec Command="npm ci"
+		      WorkingDirectory="$(MoveItUiFullDir)"
+		      IgnoreExitCode="true"
+		      Timeout="$(MoveItNpmCiTimeoutMs)">
+			<Output TaskParameter="ExitCode" PropertyName="MoveItNpmCiExit" />
+		</Exec>
+
+		<!-- Non-Debug configs: fail hard -->
+		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmCiExit)'!='0'"
+		       Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Build aborted." />
+
+		<!-- Debug: warn -->
+		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmCiExit)'!='0'"
+		         Text="MOVE IT UI: 'npm ci' failed (exit $(MoveItNpmCiExit)). Continuing (Debug)." />
+
+		<!-- Stamp written only on success; stamp file used to skip npm ci until lockfile changes again. -->
+		<WriteLinesToFile Condition="'$(MoveItNpmCiExit)'=='0'"
+		                  File="$(MoveItNpmCiStamp)"
+		                  Lines="ok"
+		                  Overwrite="true" />
+	</Target>
+
+	<!-- ============================================================
+	     UI build + copy (always run _npm run build_ when UI enabled)
+	     ============================================================
+	     Why AfterTargets=DeployWIP:
+	       - Mod.targets DeployWIP deletes and recreates $(DeployDir).
+	       - Building UI earlier can leave UI files missing after DeployWIP runs.
+	     Order:
+	       DeployWIP (toolchain) -> optional npm ci -> npm run build -> copy bin\UI -> $(DeployDir)
+	-->
+	<Target Name="CopyFiles"
+	        AfterTargets="DeployWIP"
+	        DependsOnTargets="MoveItNpmInstall"
+	        Condition="'$(RunMoveItUIBuild)'=='true' AND Exists('$(MoveItUiFullDir)\package.json')">
+
+		<Message Text="MOVE IT UI: npm run build (after DeployWIP)..." Importance="high" />
+
+		<!-- Matches original: run the UI build using prefix flag to the UI folder. -->
+		<Exec Command="npm run build --prefix $(MoveItUiDir)"
+		      WorkingDirectory="$(MSBuildProjectDirectory)"
+		      IgnoreExitCode="true"
+		      Timeout="$(MoveItNpmBuildTimeoutMs)">
 			<Output TaskParameter="ExitCode" PropertyName="MoveItNpmBuildExit" />
 		</Exec>
 
 		<!-- Non-Debug configs: fail hard -->
-		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmBuildExit)'!='0'" Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Build aborted." />
+		<Error Condition="'$(Configuration)'!='Debug' AND '$(MoveItNpmBuildExit)'!='0'"
+		       Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Build aborted." />
 
 		<!-- Debug: warn -->
-		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmBuildExit)'!='0'" Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Continuing (Debug)." />
+		<Warning Condition="'$(Configuration)'=='Debug' AND '$(MoveItNpmBuildExit)'!='0'"
+		         Text="MOVE IT UI: 'npm run build' failed (exit $(MoveItNpmBuildExit)). Continuing (Debug)." />
 
-		<WriteLinesToFile Condition="'$(MoveItNpmBuildExit)'=='0'" File="$(MoveItNpmBuildStamp)" Lines="ok" Overwrite="true" />
-	</Target>
-
-	<!-- Copy built UI into the deployed mod folder After toolchain deploy -->
-	<Target Name="CopyMoveItUIToDeploy"
-			AfterTargets="DeployWIP"
-			DependsOnTargets="MoveItUIBuild"
-			Condition="Exists('$(MSBuildProjectDirectory)\bin\UI')">
+		<!-- Enumerate AFTER build so newly generated files (images/) are included. -->
 		<ItemGroup>
 			<UIFiles Include="bin\UI\**\*.*" />
 		</ItemGroup>
 
-		<Copy SourceFiles="@(UIFiles)" DestinationFiles="@(UIFiles->'$(DeployDir)\%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+		<!-- Copy the built UI bundle into the deployed mod folder. -->
+		<Copy Condition="Exists('bin\UI')"
+		      SourceFiles="@(UIFiles)"
+		      DestinationFiles="@(UIFiles->'$(DeployDir)\%(RecursiveDir)%(Filename)%(Extension)')"
+		      SkipUnchangedFiles="true" />
 	</Target>
 
 	<Target Name="SetupAttributes" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' != 'Debug'">
@@ -263,7 +330,7 @@
 			<Private>False</Private>
 		</Reference>
 
-		<!-- Keep: removing this causes CS0518 / missing predefined types in this project -->
+		<!-- Keep: removing this causes CS0518 / missing predefined types -->
 		<Reference Include="mscorlib">
 			<Private>False</Private>
 			<HintPath>$(ManagedPath)\mscorlib.dll</HintPath>


### PR DESCRIPTION
- Runs UI build **after** toolchain `DeployWIP `so `$(DeployDir)` isn’t wiped out after UI output is produced (/images, etc).

Adds 3 build knobs:
- `RunMoveItUIBuild `(master on/off)
- `RunMoveItNpmCi `(enable/disable npm ci)
- `MoveItForceNpmCiAlways `(always vs lockfile-change stamp mode)
- Keeps existing `npm run build --prefix ..\..\UI` behavior.
- Copies bin\UI\** into `$(DeployDir) `**after** build so images/ and other UI files get to the deployed mod folder.