### PR TITLE
Fix - Decorative props treated as props, not as plants

### DIFF
--- a/Code/MoveIt/QTypes.cs
+++ b/Code/MoveIt/QTypes.cs
@@ -84,7 +84,14 @@ namespace MoveIt
             }
             else if (manager.HasComponent<Game.Objects.Plant>(e))
             {
-                return Identity.Plant;
+                if (manager.HasComponent<Game.Objects.Pillar>(e))
+                {
+                    return Identity.Prop;
+                }
+                else
+                {
+                    return Identity.Plant;
+                }
             }
             else if (manager.HasComponent<Game.Buildings.Extension>(e))
             {
@@ -143,3 +150,4 @@ namespace MoveIt
         }
     }
 }
+


### PR DESCRIPTION
Fixes the issue of having decorative props treated as plants in the filters. Having both the Pillar component and the Plant component is common practice for decorative props, allowing them to resist terraforming rotation (pillar) and to be touching or merging each other by a fair amount without Anarchy (plant).